### PR TITLE
Change findGroup to search for a single keyword

### DIFF
--- a/src/main/java/seedu/address/logic/parser/FindGroupCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindGroupCommandParser.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import java.util.Arrays;
+import java.util.List;
 
 import seedu.address.logic.commands.FindGroupCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -18,16 +19,16 @@ public class FindGroupCommandParser implements Parser<FindGroupCommand> {
      * and returns a FindGroupCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
-    public FindGroupCommand parse(String args) throws ParseException {
+    public FindGroupCommand parse(String arg) throws ParseException {
 
-        String trimmedArgs = args.trim();
+        String trimmedArgs = arg.trim();
         if (trimmedArgs.isEmpty()) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindGroupCommand.MESSAGE_USAGE));
         }
 
-        String[] groupNameKeywords = trimmedArgs.split("\\s+");
-        return new FindGroupCommand(new GroupContainsKeywordsPredicate(Arrays.asList(groupNameKeywords)));
+        List<String> keyword = Arrays.asList(trimmedArgs);
+        return new FindGroupCommand(new GroupContainsKeywordsPredicate(keyword));
 
     }
 

--- a/src/main/java/seedu/address/model/group/GroupContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/group/GroupContainsKeywordsPredicate.java
@@ -3,7 +3,6 @@ package seedu.address.model.group;
 import java.util.List;
 import java.util.function.Predicate;
 
-import seedu.address.commons.util.StringUtil;
 import seedu.address.commons.util.ToStringBuilder;
 
 /**
@@ -19,8 +18,9 @@ public class GroupContainsKeywordsPredicate implements Predicate<Group> {
     }
     @Override
     public boolean test(Group group) {
+        String lowercaseGroupName = group.getGroupName().toString().toLowerCase();
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(group.getGroupName().toString(), keyword));
+                .anyMatch(keyword -> lowercaseGroupName.contains(keyword.toLowerCase()));
     }
     @Override
     public boolean equals(Object other) {


### PR DESCRIPTION
fixes #232 

During parsing, I removed the need to split the args as its a single keyword then optimized the stream boolean generation process by just using.contain and .lowercase